### PR TITLE
Minor documentation: pass-through args to laf_open

### DIFF
--- a/R/meta.R
+++ b/R/meta.R
@@ -265,9 +265,12 @@ write_dm <- function(model, modelfile) {
 #' all the information needed to open the file (column types, column widths,
 #' etc.). 
 #' 
-#' @param model a \link{read_dm}{data model}.
+#' @param model a {data model}, such as one returned by \link{read_dm} or
+#'   \link{detect_dm_csv}.
 #' @param ... additional arguments can be used to overwrite the values specified
-#'   by the data model.
+#'   by the data model. These are listed in the argument documentation for
+#'   \code{\link{laf_open_csv}} and \code{\link{laf_open_fwf}}, e.g.
+#'   see \code{ignore_failed_conversion}.
 #' 
 #' @details
 #' Depending on the field `type' \code{laf_open} uses \code{\link{laf_open_csv}}


### PR DESCRIPTION
I found this package super-useful when I ran across it today, but it took me a while to get started as I wan't sure what were the basic building blocks. I ended up with something like this:

model <- detect_dm_csv('matrix.csv', header = TRUE, nrows = 100)
data <- laf_open(model, ignore_failed_conversion = TRUE)

I basically thought maybe this could help others make faster progress when they read the docs.