### PR TITLE
Added basic quote-respecting logic to CSVReader::determine_ncolumns()

### DIFF
--- a/src/csvreader.cpp
+++ b/src/csvreader.cpp
@@ -186,11 +186,21 @@ unsigned int CSVReader::determine_ncolumns(const std::string& filename) {
   input.seekg(offset_, std::ios::beg);
   int ncolumns = 0;
   bool empty = true;
+  bool open_quote = false;
   while (true) {
     int c = input.get();
+    if (c == '"') {
+      if(open_quote){
+          open_quote = false;
+      }else{
+          open_quote = true;
+      }
+    }
     if (c == sep_) {
-      empty = false;
-      ncolumns++;
+      if (!open_quote) {
+        empty = false;
+        ncolumns++;
+      }
     } else if ((!c) || (c == '\n')) {
       if (!empty) ncolumns++;
       break;


### PR DESCRIPTION
CSV reading was failing when the csv first line contained a quote string field which contained commas (or other separators), however if the same data occurred on any subsequent line it was parsed correctly. I noticed that the logic for tracking whether quotes are open that was present in CSVReader::next_line()  was missing from CSVReader::determine_ncolumns(), so re implemented it there. Post compilation it successfully resolved the bug.

Note: I didn't bother reimplementing the logic for detecting newlines within quotes, just the separators.

fixes #21 